### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - "0.8"
   - "0.10"
@@ -19,6 +22,28 @@ sudo: false
 cache:
   directories:
     - node_modules
+# ppc64le support code
+jobs:
+  exclude:
+    - arch: ppc64le
+      node_js:
+        - "0.8"
+    - arch: ppc64le
+      node_js:
+        - "0.10"
+    - arch: ppc64le
+      node_js:
+        - "0.12"
+    - arch: ppc64le
+      node_js:
+        - "1.8"
+    - arch: ppc64le
+      node_js:
+        - "2.5"
+    - arch: ppc64le
+      node_js:
+        - "3.3"
+    
 before_install:
   - |
     # Setup utility functions


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/on-finished/builds/206963074