### PR TITLE
breaking: convert package to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.nyc_output
 coverage
 node_modules
 npm-debug.log
-package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,82 +1,12 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "1.8"
-  - "2.5"
-  - "3.3"
-  - "4.9"
-  - "5.12"
-  - "6.17"
-  - "7.10"
-  - "8.17"
-  - "10.24"
-  - "11.15"
-  - "12.22"
-  - "13.14"
-  - "14.16"
-  - "15.13"
+  - "12.20.0"
+  - "14.13.1"
+  - "16.0.0"
 cache:
   directories:
     - node_modules
 before_install:
-  - |
-    # Setup utility functions
-    function node_version_lt () {
-      [[ "$(v "$TRAVIS_NODE_VERSION")" -lt "$(v "${1}")" ]]
-    }
-    function npm_module_installed () {
-      npm -lsp ls | grep -Fq "$(pwd)/node_modules/${1}:${1}@"
-    }
-    function npm_remove_module_re () {
-      node -e '
-        fs = require("fs");
-        p = JSON.parse(fs.readFileSync("package.json", "utf8"));
-        r = RegExp(process.argv[1]);
-        for (k in p.devDependencies) {
-          if (r.test(k)) delete p.devDependencies[k];
-        }
-        fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
-      ' "$@"
-    }
-    function npm_use_module () {
-      node -e '
-        fs = require("fs");
-        p = JSON.parse(fs.readFileSync("package.json", "utf8"));
-        p.devDependencies[process.argv[1]] = process.argv[2];
-        fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
-      ' "$@"
-    }
-    function v () {
-      tr '.' '\n' <<< "${1}" \
-        | awk '{ printf "%03d", $0 }' \
-        | sed 's/^0*//'
-    }
-  # Configure npm
-  - |
-    # Skip updating shrinkwrap / lock
-    npm config set shrinkwrap false
-  # Setup Node.js version-specific dependencies
-  - |
-    # Configure eslint for linting
-    if node_version_lt '10.0'; then npm_remove_module_re '^eslint(-|$)'
-    fi
-  - |
-    # Configure mocha for testing
-    if   node_version_lt '0.10'; then npm_use_module 'mocha' '2.5.3'
-    elif node_version_lt '4.0' ; then npm_use_module 'mocha' '3.5.3'
-    elif node_version_lt '6.0' ; then npm_use_module 'mocha' '5.2.0'
-    elif node_version_lt '8.0' ; then npm_use_module 'mocha' '6.2.2'
-    elif node_version_lt '10.0'; then npm_use_module 'mocha' '7.2.0'
-    fi
-  - |
-    # Configure nyc for coverage
-    if   node_version_lt '0.10'; then npm_remove_module_re '^nyc$'
-    elif node_version_lt '4.0' ; then npm_use_module 'nyc' '10.3.2'
-    elif node_version_lt '6.0' ; then npm_use_module 'nyc' '11.9.0'
-    elif node_version_lt '8.0' ; then npm_use_module 'nyc' '14.1.1'
-    fi
   # Update Node.js modules
   - |
     # Prune and rebuild node_modules
@@ -90,18 +20,13 @@ before_script:
     npm -s ls ||:
 script:
   - |
-    # Run test script, depending on nyc install
-    if npm_module_installed 'nyc'; then npm run-script test-ci
-    else npm test
-    fi
+    # Run test script
+    npm run-script test-ci
   - |
-    # Run linting, if eslint exists
-    if npm_module_installed 'eslint'; then npm run-script lint
-    fi
+    # Run linting
+    npm run-script lint
 after_script:
   - |
     # Upload coverage to coveralls
-    if [[ -d .nyc_output ]]; then
-      npm install --save-dev coveralls@2.13.3
-      nyc report --reporter=text-lcov | coveralls
-    fi
+    npm install --save-dev coveralls@2.13.3
+    c8 report --reporter=text-lcov | coveralls

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install on-finished
 ## API
 
 ```js
-var onFinished = require('on-finished')
+import onFinished from 'on-finished'
 ```
 
 ### onFinished(res, listener)
@@ -72,12 +72,12 @@ onFinished(req, function (err, req) {
 })
 ```
 
-### onFinished.isFinished(res)
+### isFinished(res)
 
 Determine if `res` is already finished. This would be useful to check and
 not even start certain operations if the response has already finished.
 
-### onFinished.isFinished(req)
+### isFinished(req)
 
 Determine if `req` is already finished. This would be useful to check and
 not even start certain operations if the request has already finished.
@@ -133,10 +133,10 @@ The following code ensures that file descriptors are always closed
 once the response finishes.
 
 ```js
-var destroy = require('destroy')
-var fs = require('fs')
-var http = require('http')
-var onFinished = require('on-finished')
+import destroy from 'destroy'
+import fs from 'node:fs'
+import http from 'node:http'
+import onFinished from 'on-finished'
 
 http.createServer(function onRequest (req, res) {
   var stream = fs.createReadStream('package.json')

--- a/index.js
+++ b/index.js
@@ -5,29 +5,19 @@
  * MIT Licensed
  */
 
-'use strict'
-
-/**
- * Module exports.
- * @public
- */
-
-module.exports = onFinished
-module.exports.isFinished = isFinished
-
 /**
  * Module dependencies.
  * @private
  */
 
-var first = require('ee-first')
+import first from 'ee-first'
 
 /**
  * Variables.
  * @private
  */
 
-/* istanbul ignore next */
+/* c8 ignore next */
 var defer = typeof setImmediate === 'function'
   ? setImmediate
   : function (fn) { process.nextTick(fn.bind.apply(fn, arguments)) }
@@ -42,7 +32,7 @@ var defer = typeof setImmediate === 'function'
  * @public
  */
 
-function onFinished (msg, listener) {
+export default function onFinished (msg, listener) {
   if (isFinished(msg) !== false) {
     defer(listener, null, msg)
     return msg
@@ -62,7 +52,7 @@ function onFinished (msg, listener) {
  * @public
  */
 
-function isFinished (msg) {
+export function isFinished (msg) {
   var socket = msg.socket
 
   if (typeof msg.finished === 'boolean') {
@@ -122,11 +112,6 @@ function attachFinishedListener (msg, callback) {
 
   // wait for socket to be assigned
   msg.on('socket', onSocket)
-
-  if (msg.socket === undefined) {
-    // istanbul ignore next: node.js 0.8 patch
-    patchAssignSocket(msg, onSocket)
-  }
 }
 
 /**
@@ -173,25 +158,4 @@ function createListener (msg) {
   listener.queue = []
 
   return listener
-}
-
-/**
- * Patch ServerResponse.prototype.assignSocket for node.js 0.8.
- *
- * @param {ServerResponse} res
- * @param {function} callback
- * @private
- */
-
-// istanbul ignore next: node.js 0.8 patch
-function patchAssignSocket (res, callback) {
-  var assignSocket = res.assignSocket
-
-  if (typeof assignSocket !== 'function') return
-
-  // res.on('socket', callback) is broken in 0.8
-  res.assignSocket = function _assignSocket (socket) {
-    assignSocket.call(this, socket)
-    callback(socket)
-  }
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   ],
   "license": "MIT",
   "repository": "jshttp/on-finished",
+  "type": "module",
+  "exports": "./index.js",
   "dependencies": {
     "ee-first": "1.1.1"
   },
   "devDependencies": {
+    "c8": "7.7.3",
     "eslint": "7.23.0",
     "eslint-config-standard": "14.1.1",
     "eslint-plugin-import": "2.22.1",
@@ -19,11 +22,10 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.3.1",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "8.3.2",
-    "nyc": "15.1.0"
+    "mocha": "8.3.2"
   },
   "engines": {
-    "node": ">= 0.8"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "files": [
     "HISTORY.md",
@@ -33,7 +35,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --reporter spec --bail --check-leaks test/",
-    "test-ci": "nyc --reporter=lcov --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test-ci": "c8 --reporter=lcov --reporter=text npm test",
+    "test-cov": "c8 --reporter=html --reporter=text npm test"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,7 @@
-
-var assert = require('assert')
-var http = require('http')
-var net = require('net')
-var onFinished = require('..')
+import assert from 'node:assert'
+import http from 'node:http'
+import net from 'node:net'
+import onFinished, { isFinished } from '../index.js'
 
 describe('onFinished(res, listener)', function () {
   it('should invoke listener given an unknown object', function (done) {
@@ -214,12 +213,12 @@ describe('onFinished(res, listener)', function () {
 
 describe('isFinished(res)', function () {
   it('should return undefined for unknown object', function () {
-    assert.strictEqual(onFinished.isFinished({}), undefined)
+    assert.strictEqual(isFinished({}), undefined)
   })
 
   it('should be false before response finishes', function (done) {
     var server = http.createServer(function (req, res) {
-      assert.ok(!onFinished.isFinished(res))
+      assert.ok(!isFinished(res))
       res.end()
       done()
     })
@@ -231,7 +230,7 @@ describe('isFinished(res)', function () {
     var server = http.createServer(function (req, res) {
       onFinished(res, function (err) {
         assert.ifError(err)
-        assert.ok(onFinished.isFinished(res))
+        assert.ok(isFinished(res))
         done()
       })
 
@@ -255,8 +254,8 @@ describe('isFinished(res)', function () {
             return
           }
 
-          assert.ok(!onFinished.isFinished(responses[0]))
-          assert.ok(!onFinished.isFinished(responses[1]))
+          assert.ok(!isFinished(responses[0]))
+          assert.ok(!isFinished(responses[1]))
 
           responses[0].end()
           responses[1].end()
@@ -322,7 +321,7 @@ describe('isFinished(res)', function () {
       var server = http.createServer(function (req, res) {
         onFinished(res, function (err) {
           assert.ok(err)
-          assert.ok(onFinished.isFinished(res))
+          assert.ok(isFinished(res))
           server.close(done)
         })
 
@@ -345,7 +344,7 @@ describe('isFinished(res)', function () {
       var server = http.createServer(function (req, res) {
         onFinished(res, function (err) {
           assert.ifError(err)
-          assert.ok(onFinished.isFinished(res))
+          assert.ok(isFinished(res))
           server.close(done)
         })
         setTimeout(client.abort.bind(client), 0)
@@ -758,12 +757,12 @@ describe('onFinished(req, listener)', function () {
 
 describe('isFinished(req)', function () {
   it('should return undefined for unknown object', function () {
-    assert.strictEqual(onFinished.isFinished({}), undefined)
+    assert.strictEqual(isFinished({}), undefined)
   })
 
   it('should be false before request finishes', function (done) {
     var server = http.createServer(function (req, res) {
-      assert.ok(!onFinished.isFinished(req))
+      assert.ok(!isFinished(req))
       req.resume()
       res.end()
       done()
@@ -776,7 +775,7 @@ describe('isFinished(req)', function () {
     var server = http.createServer(function (req, res) {
       onFinished(req, function (err) {
         assert.ifError(err)
-        assert.ok(onFinished.isFinished(req))
+        assert.ok(isFinished(req))
         done()
       })
 
@@ -790,11 +789,11 @@ describe('isFinished(req)', function () {
   describe('when request data buffered', function () {
     it('should be false before request finishes', function (done) {
       var server = http.createServer(function (req, res) {
-        assert.ok(!onFinished.isFinished(req))
+        assert.ok(!isFinished(req))
 
         req.pause()
         setTimeout(function () {
-          assert.ok(!onFinished.isFinished(req))
+          assert.ok(!isFinished(req))
           req.resume()
           res.end()
           done()
@@ -810,7 +809,7 @@ describe('isFinished(req)', function () {
       var server = http.createServer(function (req, res) {
         onFinished(req, function (err) {
           assert.ok(err)
-          assert.ok(onFinished.isFinished(req))
+          assert.ok(isFinished(req))
           server.close(done)
         })
 
@@ -833,7 +832,7 @@ describe('isFinished(req)', function () {
       var server = http.createServer(function (req, res) {
         onFinished(res, function (err) {
           assert.ifError(err)
-          assert.ok(onFinished.isFinished(req))
+          assert.ok(isFinished(req))
           server.close(done)
         })
         setTimeout(client.abort.bind(client), 0)
@@ -855,7 +854,7 @@ describe('isFinished(req)', function () {
       })
 
       server.on('connect', function (req, socket, bodyHead) {
-        assert.ok(onFinished.isFinished(req))
+        assert.ok(isFinished(req))
         assert.strictEqual(bodyHead.length, 0)
         req.resume()
 
@@ -897,7 +896,7 @@ describe('isFinished(req)', function () {
 
         onFinished(req, function (err) {
           assert.ifError(err)
-          assert.ok(onFinished.isFinished(req))
+          assert.ok(isFinished(req))
           assert.strictEqual(Buffer.concat(data).toString(), 'knock, knock')
           socket.write('HTTP/1.1 200 OK\r\n\r\n')
         })
@@ -941,7 +940,7 @@ describe('isFinished(req)', function () {
       })
 
       server.on('upgrade', function (req, socket, bodyHead) {
-        assert.ok(onFinished.isFinished(req))
+        assert.ok(isFinished(req))
         assert.strictEqual(bodyHead.length, 0)
         req.resume()
 
@@ -988,7 +987,7 @@ describe('isFinished(req)', function () {
 
         onFinished(req, function (err) {
           assert.ifError(err)
-          assert.ok(onFinished.isFinished(req))
+          assert.ok(isFinished(req))
           assert.strictEqual(Buffer.concat(data).toString(), 'knock, knock')
 
           socket.write('HTTP/1.1 101 Switching Protocols\r\n')


### PR DESCRIPTION
This might be a bit premature since it quite aggressively cuts of older versions of Node.js, but I'm ([and other maintainers](https://github.com/sindresorhus/meta/discussions/15)) moving over my packages to ESM and would love a version 3.x of `on-finished` that has ESM support.

-----

Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`