### PR TITLE
Avoided to write status message for HTTP/2

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ function createListener (msg) {
     listener.queue = null
 
     for (var i = 0; i < queue.length; i++) {
-      if (msg instanceof http2.Http2ServerRequest) {
+      if (msg.httpVersionMajor === 2) {
         queue[i]()
       } else {
         queue[i](err, msg)

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports.isFinished = isFinished
 
 var asyncHooks = tryRequireAsyncHooks()
 var first = require('ee-first')
-var http2 = require('http2')
 
 /**
  * Variables.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports.isFinished = isFinished
 
 var asyncHooks = tryRequireAsyncHooks()
 var first = require('ee-first')
+var { Http2ServerRequest } = require('http2')
 
 /**
  * Variables.
@@ -167,7 +168,11 @@ function createListener (msg) {
     listener.queue = null
 
     for (var i = 0; i < queue.length; i++) {
-      queue[i](err, msg)
+      if (msg instanceof Http2ServerRequest) {
+        queue[i]();
+      } else {
+        queue[i](err, msg)
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports.isFinished = isFinished
 
 var asyncHooks = tryRequireAsyncHooks()
 var first = require('ee-first')
-var { Http2ServerRequest } = require('http2')
+var http2 = require('http2')
 
 /**
  * Variables.
@@ -168,8 +168,8 @@ function createListener (msg) {
     listener.queue = null
 
     for (var i = 0; i < queue.length; i++) {
-      if (msg instanceof Http2ServerRequest) {
-        queue[i]();
+      if (msg instanceof http2.Http2ServerRequest) {
+        queue[i]()
       } else {
         queue[i](err, msg)
       }


### PR DESCRIPTION
Currently node warns if using HTTP/2 as follows:
```
(node:53810) UnsupportedWarning: Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)
```
In order to fit to the spec of HTTP/2, avoided to write status message.