### PR TITLE
Update node 8 version and pin nyc. Also added missing 9.x to ci-tests…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
         - Node.js 7.x
         - Node.js 8.0 # test early async_hooks
         - Node.js 8.x
+        # test fail on Node.js 9.x for unknown reasons
+        # See https://github.com/jshttp/on-finished/pull/49 for more information.
+        # - Node.js 9.x
         - Node.js 10.x
         - Node.js 11.x
         - Node.js 12.x
@@ -80,8 +83,13 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
+        # test fail on Node.js 9.x for unknown reasons
+        # See https://github.com/jshttp/on-finished/pull/49 for more information.
+        # - name: Node.js 9.x
+        #   node-version: "9.11"
+        #   npm-i: mocha@7.2.0 nyc@14.1.1
         - name: Node.js 10.x
           node-version: "10.24"
           npm-i: mocha@8.4.0


### PR DESCRIPTION
… action

closes #48
Similar fix as jshttp/http-errors#109