### PR TITLE
refactor: remove unused error parameter from `tryRequireAsyncHooks` catch block

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,13 +199,15 @@ function patchAssignSocket (res, callback) {
 
 /**
  * Try to require async_hooks
+ *
+ * @returns {Object}
  * @private
  */
 
 function tryRequireAsyncHooks () {
   try {
     return require('async_hooks')
-  } catch (e) {
+  } catch {
     return {}
   }
 }


### PR DESCRIPTION
refactor: remove unused error parameter from `tryRequireAsyncHooks` catch block

- Simplified `tryRequireAsyncHooks` by removing the unused error parameter in the `catch` block.
- Updated JSDoc for improved clarity on function behavior.
