### PR TITLE
refactor: use stream.finished() instead of custom implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   ],
   "license": "MIT",
   "repository": "jshttp/on-finished",
-  "dependencies": {
-    "ee-first": "1.1.1"
-  },
   "devDependencies": {
     "eslint": "8.17.0",
     "eslint-config-standard": "14.1.1",
@@ -32,7 +29,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --reporter spec --bail --check-leaks test/",
+    "test": "mocha --reporter spec --check-leaks test/",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }


### PR DESCRIPTION
### Context

There have been previous efforts to modernize usage of `on-finished`, particularly around replacing it with [`stream.finished()`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback), while still depending on `isFinished()` method from `on-finished`.
This PR tries to consolidate and properly implement those ideas within `on-finished` itself.

Related PRs:

- https://github.com/pillarjs/finalhandler/pull/95
- https://github.com/expressjs/express/pull/6414
- https://github.com/expressjs/body-parser/pull/598

### Changes

This pull request refactors the `on-finished` package to use the native [`stream.finished()`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback) while maintaining compatibility with previous behaviour.

* Replaced the `ee-first` library with the `stream.finished` utility from Node.js for handling message and socket events, improving compatibility with modern Node.js versions. (`index.js`, [index.jsL92-R137](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L92-R137))
* Removed legacy patches for Node.js 0.8, including `patchAssignSocket` and `tryRequireAsyncHooks` functions, as they are no longer relevant. (`index.js`, [index.jsL179-R182](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L179-R182))

### BREAKING CHANGES

[`stream.finished()`](https://nodejs.org/api/stream.html#streamfinishedstream-options-callback) is available since Node.js 10.0.0.

------------------------------------
cc: @bjohansebas @UlisesGascon