### PR TITLE
feat: add types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint code
         run: npm run lint
 
+      - name: Check types
+        run: npm run test-types
+
   test:
     name: Test - Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@ unreleased
   * Breaking Change: Node.js 18 is the minimum supported version
   * Validate that passed `listener` is a function
   * Add official HTTP/2 support for both compatibility mode and native streams
+  * Add types
 
 2.4.1 / 2022-02-22
 ==================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@ unreleased
   * Breaking Change: Node.js 18 is the minimum supported version
   * Validate that passed `listener` is a function
   * Add official HTTP/2 support for both compatibility mode and native streams
-  * Add types
+  * Add TypeScript definitions for improved type safety and IDE support
 
 2.4.1 / 2022-02-22
 ==================

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+
+import { IncomingMessage, ServerResponse } from "node:http";
+
+declare function onFinished<T extends IncomingMessage | ServerResponse>(
+  msg: T,
+  listener: (err: Error | null | undefiend, msg: T) => void
+): T;
+
+declare namespace onFinished {
+  function isFinished(msg: IncomingMessage | ServerResponse): boolean;
+}
+
+export = onFinished;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import { IncomingMessage, ServerResponse } from "node:http";
 
 declare function onFinished<T extends IncomingMessage | ServerResponse>(
   msg: T,
-  listener: (err: Error | null | undefiend, msg: T) => void
+  listener: (err: Error | null | undefined, msg: T) => void
 ): T;
 
 declare namespace onFinished {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare function onFinished<T extends IncomingMessage | ServerResponse>(
 ): T;
 
 declare namespace onFinished {
-  function isFinished(msg: IncomingMessage | ServerResponse): boolean;
+  function isFinished(msg: IncomingMessage | ServerResponse): boolean | undefined;
 }
 
 export = onFinished;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 
-import { IncomingMessage, ServerResponse } from "node:http";
+import { IncomingMessage, OutgoingMessage } from "node:http";
 
-declare function onFinished<T extends IncomingMessage | ServerResponse>(
+declare function onFinished<T extends IncomingMessage | OutgoingMessage>(
   msg: T,
   listener: (err: Error | null | undefined, msg: T) => void
 ): T;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function onFinished (msg, listener) {
  * Determine if message is already finished.
  *
  * @param {object} msg
- * @return {boolean}
+ * @return {boolean | undefined}
  * @public
  */
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
   ],
   "license": "MIT",
   "repository": "jshttp/on-finished",
+  "type": "commonjs",
+  "main": "index.js",
+  "types": "index.d.ts",
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
+    "@tsconfig/node18": "^18.2.4",
+    "@types/node": "^18.19.122",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.31.0",
@@ -16,8 +22,10 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-standard": "^4.1.0",
+    "expect-type": "^1.2.2",
     "mocha": "^11.7.0",
-    "nyc": "^17.1.0"
+    "nyc": "^17.1.0",
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=18"
@@ -25,12 +33,14 @@
   "files": [
     "HISTORY.md",
     "LICENSE",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --reporter spec --check-leaks --exit test/",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test-cov": "nyc --reporter=html --reporter=text npm test",
+    "test-types": "tsc --noEmit && attw --pack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "main": "index.js",
   "types": "index.d.ts",
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
-    "@tsconfig/node18": "^18.2.4",
-    "@types/node": "^18.19.122",
+    "@arethetypeswrong/cli": "^0.18.4",
+    "@tsconfig/node18": "^18.2.6",
+    "@types/node": "^18.19.130",
     "eslint": "^8.57.1",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.31.0",
@@ -22,10 +22,10 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-standard": "^4.1.0",
-    "expect-type": "^1.2.2",
+    "expect-type": "^1.4.0",
     "mocha": "^11.7.0",
     "nyc": "^17.1.0",
-    "typescript": "^5.9.2"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18"

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,22 @@
+import { IncomingMessage, ServerResponse, createServer } from "node:http";
+import { expectTypeOf } from "expect-type";
+import onFinished, { isFinished } from "..";
+
+createServer((req, res) => {
+  onFinished(req, (err, req) => {
+    expectTypeOf(err).toEqualTypeOf<Error | null | undefined>();
+    expectTypeOf(req).toEqualTypeOf<IncomingMessage>();
+  });
+
+  onFinished(res, (err, res) => {
+    expectTypeOf(err).toEqualTypeOf<Error | null | undefined>();
+    expectTypeOf(res).toEqualTypeOf<
+      ServerResponse<IncomingMessage> & {
+        req: IncomingMessage;
+      }
+    >();
+  });
+
+  expectTypeOf(isFinished(req)).toEqualTypeOf<boolean>();
+  expectTypeOf(isFinished(res)).toEqualTypeOf<boolean>();
+});

--- a/test/types.ts
+++ b/test/types.ts
@@ -10,11 +10,7 @@ createServer((req, res) => {
 
   onFinished(res, (err, res) => {
     expectTypeOf(err).toEqualTypeOf<Error | null | undefined>();
-    expectTypeOf(res).toEqualTypeOf<
-      ServerResponse<IncomingMessage> & {
-        req: IncomingMessage;
-      }
-    >();
+    expectTypeOf(res).toExtend<ServerResponse>();
   });
 
   expectTypeOf(isFinished(req)).toEqualTypeOf<boolean>();

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse, createServer } from "node:http";
+import { IncomingMessage, OutgoingMessage, createServer } from "node:http";
 import { expectTypeOf } from "expect-type";
 import onFinished, { isFinished } from "..";
 
@@ -10,7 +10,7 @@ createServer((req, res) => {
 
   onFinished(res, (err, res) => {
     expectTypeOf(err).toEqualTypeOf<Error | null | undefined>();
-    expectTypeOf(res).toExtend<ServerResponse>();
+    expectTypeOf(res).toExtend<OutgoingMessage>();
   });
 
   expectTypeOf(isFinished(req)).toEqualTypeOf<boolean | undefined>();

--- a/test/types.ts
+++ b/test/types.ts
@@ -14,5 +14,5 @@ createServer((req, res) => {
   });
 
   expectTypeOf(isFinished(req)).toEqualTypeOf<boolean | undefined>();
-  expectTypeOf(isFinished(res)).toEqualTypeOf<boolean>();
+  expectTypeOf(isFinished(res)).toEqualTypeOf<boolean | undefined>();
 });

--- a/test/types.ts
+++ b/test/types.ts
@@ -13,6 +13,6 @@ createServer((req, res) => {
     expectTypeOf(res).toExtend<ServerResponse>();
   });
 
-  expectTypeOf(isFinished(req)).toEqualTypeOf<boolean>();
+  expectTypeOf(isFinished(req)).toEqualTypeOf<boolean | undefined>();
   expectTypeOf(isFinished(res)).toEqualTypeOf<boolean>();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "include": ["index.d.ts", "test/types.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
-  "include": ["index.d.ts", "test/types.ts"]
+  "include": ["index.d.ts", "test/types.ts"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }


### PR DESCRIPTION
This PR adds type definitions to finalhandler. It includes the following changes:

* added types
* adding `type`, `main` and `types` field to `package.json`
* adding a tsconfig.json which extends `@tsconfig/node18` from https://github.com/tsconfig/bases
* adding type tests with [`@arethetypeswrong/cli`](https://www.npmjs.com/package/@arethetypeswrong/cli) and [`expect-type`](https://www.npmjs.com/package/expect-type) and run them in the CI Pipeline

Ref: https://github.com/expressjs/typescript-wg/issues/1

cc @RobinTail