### PR TITLE
deps: update dependencies and switch fixed versions to caret (^)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "license": "MIT",
   "repository": "jshttp/on-finished",
   "devDependencies": {
-    "eslint": "8.17.0",
-    "eslint-config-standard": "14.1.1",
-    "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-markdown": "2.2.1",
-    "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "6.0.0",
-    "eslint-plugin-standard": "4.1.0",
-    "mocha": "10.0.0",
-    "nyc": "15.1.0"
+    "eslint": "^8.57.1",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-markdown": "^2.2.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-standard": "^4.1.0",
+    "mocha": "^11.7.0",
+    "nyc": "^17.1.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Converted fixed versions to caret (^) notation  and updated dependencies: 

* Updated `eslint` from `8.17.0` to `^8.57.1`.
* Updated `eslint-plugin-import` from `2.26.0` to `^2.31.0`.
* Updated `eslint-plugin-promise` from `6.0.0` to `^7.2.1`.
* Updated `mocha` from `10.0.0` to `^11.7.0`.
* Updated `nyc` from `15.1.0` to `^17.1.0`.