### PR TITLE
feat: validate that passed `listener` is a function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==================
 
   * Breaking Change: Node.js 18 is the minimum supported version
+  * Validate that passed `listener` is a function
 
 2.4.1 / 2022-02-22
 ==================

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ const stream = require('node:stream')
  */
 
 function onFinished (msg, listener) {
+  if (typeof listener !== 'function') {
+    throw new TypeError('listener must be a function')
+  }
+
   if (isFinished(msg) !== false) {
     setImmediate(listener, null, msg)
     return msg

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,10 @@ describe('onFinished(res, listener)', function () {
     onFinished({}, done)
   })
 
+  it('should throw TypeError if listener is not a function', function () {
+    assert.throws(() => { onFinished({}, 'not a function') }, /listener must be a function/)
+  })
+
   describe('when the response finishes', function () {
     it('should fire the callback', function (done) {
       var server = http.createServer(function (req, res) {
@@ -407,6 +411,10 @@ describe('isFinished(res)', function () {
 })
 
 describe('onFinished(req, listener)', function () {
+  it('should throw TypeError if listener is not a function', function () {
+    assert.throws(() => { onFinished({}, 'not a function') }, /listener must be a function/)
+  })
+
   describe('when the request finishes', function () {
     it('should fire the callback', function (done) {
       var server = http.createServer(function (req, res) {


### PR DESCRIPTION
This PR adds a type check to the `onFinished` function to ensure that the `listener` argument is a function. If a non-function is passed, it now throws a `TypeError`. I also added test cases for the error case.