### PR TITLE
Added HTTP/2 support for onFinished and isFinished functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports.isFinished = isFinished
  */
 
 const { AsyncResource } = require('node:async_hooks')
+const http2 = require('node:http2')
 const stream = require('node:stream')
 
 /** Symbol to store the listener on the message.
@@ -76,6 +77,16 @@ function isFinished (msg) {
   if (typeof msg.complete === 'boolean') {
     // IncomingMessage
     return Boolean(msg.upgrade || !socket || !socket.readable || (msg.complete && !msg.readable))
+  }
+
+  // HTTP/2 response
+  if (http2.Http2ServerResponse && msg instanceof http2.Http2ServerResponse) {
+    return Boolean(msg.stream.destroyed || msg.stream.closed)
+  }
+
+  // HTTP/2 stream
+  if (http2.Http2Stream && msg instanceof http2.Http2Stream) {
+    return Boolean(msg.destroyed || msg.closed)
   }
 
   // don't know

--- a/index.js
+++ b/index.js
@@ -67,19 +67,25 @@ function onFinished (msg, listener) {
 
 function isFinished (msg) {
   const socket = msg.socket
-  const stream = msg.stream
-  // HTTP/2 streams have destroyed property but no socket or stream properties
-  const isHttp2 = typeof msg.destroyed === 'boolean' && !socket && !stream
+  const isHttp2 = typeof msg.respond === 'function' && !socket
 
   // OutgoingMessage or Http2ServerResponse
   if (typeof msg.writableEnded === 'boolean') {
-    if (isHttp2) return Boolean(msg.destroyed || msg.writableEnded)
+    if (isHttp2) {
+      console.log('http2')
+      return Boolean(msg.destroyed || msg.writableEnded)
+    }
+    console.log('http1')
     return Boolean(msg.writableEnded || (socket && !socket.writable))
   }
 
   // IncomingMessage or Http2ServerRequest
   if (typeof msg.complete === 'boolean') {
-    if (isHttp2) return Boolean(msg.destroyed || (msg.complete && !msg.readable))
+    if (isHttp2) {
+      console.log('http2')
+      return Boolean(msg.destroyed || (msg.complete && !msg.readable))
+    }
+    console.log('http1')
     return Boolean(msg.upgrade || !socket || !socket.readable || (msg.complete && !msg.readable))
   }
 

--- a/index.js
+++ b/index.js
@@ -71,21 +71,13 @@ function isFinished (msg) {
 
   // OutgoingMessage or Http2ServerResponse
   if (typeof msg.writableEnded === 'boolean') {
-    if (isHttp2) {
-      console.log('http2')
-      return Boolean(msg.destroyed || msg.writableEnded)
-    }
-    console.log('http1')
+    if (isHttp2) return Boolean(msg.destroyed || msg.writableEnded)
     return Boolean(msg.writableEnded || (socket && !socket.writable))
   }
 
   // IncomingMessage or Http2ServerRequest
   if (typeof msg.complete === 'boolean') {
-    if (isHttp2) {
-      console.log('http2')
-      return Boolean(msg.destroyed || (msg.complete && !msg.readable))
-    }
-    console.log('http1')
+    if (isHttp2) return Boolean(msg.destroyed || (msg.complete && !msg.readable))
     return Boolean(msg.upgrade || !socket || !socket.readable || (msg.complete && !msg.readable))
   }
 

--- a/test/http2.js
+++ b/test/http2.js
@@ -1,0 +1,393 @@
+const assert = require('node:assert')
+const { AsyncLocalStorage } = require('node:async_hooks')
+const http2 = require('node:http2')
+const onFinished = require('..')
+
+describe('HTTP/2', function () {
+  describe('onFinished(res, listener)', function () {
+    describe('with ServerResponse', function () {
+      it('should fire when response finishes', function (done) {
+        const server = http2.createServer()
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, done)
+          stream.respond({ ':status': 200 })
+          setTimeout(() => stream.end('hello world'), 10)
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+          const req = client.request({ ':path': '/' })
+
+          req.on('response', () => {
+            req.on('end', () => {
+              client.close()
+              server.close()
+            })
+          })
+          req.end()
+        })
+      })
+
+      it('should include the stream object', function (done) {
+        const server = http2.createServer()
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, (err, msg) => {
+            assert.ok(!err)
+            assert.strictEqual(msg, stream)
+            done()
+          })
+          stream.respond({ ':status': 200 })
+          setTimeout(() => stream.end('hello world'), 10)
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+          const req = client.request({ ':path': '/' })
+
+          req.on('response', () => {
+            req.on('end', () => {
+              client.close()
+              server.close()
+            })
+          })
+          req.end()
+        })
+      })
+
+      it('should fire when response is destroyed', function (done) {
+        const server = http2.createServer()
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, done)
+          stream.respond({ ':status': 200 })
+          setTimeout(() => stream.destroy(), 10)
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+          const req = client.request({ ':path': '/' })
+
+          req.on('error', () => {
+            // Ignore client error
+          })
+
+          req.on('close', () => {
+            client.close()
+            server.close()
+          })
+
+          req.end()
+        })
+      })
+
+      describe('when called after finish', function () {
+        it('should fire immediately', function (done) {
+          const server = http2.createServer()
+
+          server.on('stream', (stream, headers) => {
+            onFinished(stream, () => {
+              onFinished(stream, done)
+            })
+            stream.respond({ ':status': 200 })
+            setTimeout(() => stream.end('hello world'), 10)
+          })
+
+          server.listen(0, function () {
+            const port = server.address().port
+            const client = http2.connect(`http://localhost:${port}`)
+            const req = client.request({ ':path': '/' })
+
+            req.on('response', () => {
+              req.on('end', () => {
+                client.close()
+                server.close()
+              })
+            })
+            req.end()
+          })
+        })
+
+        describe('with async local storage', function () {
+          it('should persist store in callback', function (done) {
+            const asyncLocalStorage = new AsyncLocalStorage()
+            const store = { foo: 'bar' }
+
+            const server = http2.createServer()
+
+            server.on('stream', (stream, headers) => {
+              onFinished(stream, () => {
+                asyncLocalStorage.run(store, () => {
+                  onFinished(stream, () => {
+                    assert.strictEqual(asyncLocalStorage.getStore().foo, 'bar')
+                    done()
+                  })
+                })
+              })
+              stream.respond({ ':status': 200 })
+              setTimeout(() => stream.end('hello world'), 10)
+            })
+
+            server.listen(0, function () {
+              const port = server.address().port
+              const client = http2.connect(`http://localhost:${port}`)
+              const req = client.request({ ':path': '/' })
+
+              req.on('response', () => {
+                req.on('end', () => {
+                  client.close()
+                  server.close()
+                })
+              })
+              req.end()
+            })
+          })
+        })
+      })
+
+      describe('with async local storage', function () {
+        it('should persist store in callback', function (done) {
+          const asyncLocalStorage = new AsyncLocalStorage()
+          const store = { foo: 'bar' }
+
+          const server = http2.createServer()
+
+          server.on('stream', (stream, headers) => {
+            asyncLocalStorage.run(store, () => {
+              onFinished(stream, () => {
+                assert.strictEqual(asyncLocalStorage.getStore().foo, 'bar')
+                done()
+              })
+            })
+            stream.respond({ ':status': 200 })
+            setTimeout(() => stream.end('hello world'), 10)
+          })
+
+          server.listen(0, function () {
+            const port = server.address().port
+            const client = http2.connect(`http://localhost:${port}`)
+            const req = client.request({ ':path': '/' })
+
+            req.on('response', () => {
+              req.on('end', () => {
+                client.close()
+                server.close()
+              })
+            })
+            req.end()
+          })
+        })
+      })
+    })
+
+    describe('with multiple streams', function () {
+      it('should fire for each stream independently', function (done) {
+        const server = http2.createServer()
+        let count = 0
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, () => {
+            count++
+            if (count === 2) {
+              done()
+            }
+          })
+          stream.respond({ ':status': 200 })
+          setTimeout(() => stream.end(`response ${count}`), 10)
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+
+          const req1 = client.request({ ':path': '/1' })
+          const req2 = client.request({ ':path': '/2' })
+
+          let responses = 0
+
+          req1.on('response', () => {
+            req1.on('end', () => {
+              responses++
+              if (responses === 2) {
+                client.close()
+                server.close()
+              }
+            })
+          })
+          req1.end()
+
+          req2.on('response', () => {
+            req2.on('end', () => {
+              responses++
+              if (responses === 2) {
+                client.close()
+                server.close()
+              }
+            })
+          })
+          req2.end()
+        })
+      })
+    })
+
+    describe('when client closes connection', function () {
+      it('should fire the callback', function (done) {
+        const server = http2.createServer()
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, () => {
+            done()
+          })
+          stream.respond({ ':status': 200 })
+          // Don't end the stream, let client close it
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+          const req = client.request({ ':path': '/' })
+
+          req.on('response', () => {
+            setTimeout(() => {
+              req.close()
+              setTimeout(() => {
+                client.close()
+                server.close()
+              }, 50)
+            }, 10)
+          })
+
+          req.on('error', () => {
+            // Ignore client errors
+          })
+
+          req.end()
+        })
+      })
+    })
+
+    describe('when stream errors', function () {
+      it('should fire the callback', function (done) {
+        const server = http2.createServer()
+
+        server.on('stream', (stream, headers) => {
+          onFinished(stream, () => {
+            done()
+          })
+          stream.respond({ ':status': 200 })
+          setTimeout(() => {
+            stream.destroy()
+          }, 10)
+        })
+
+        server.listen(0, function () {
+          const port = server.address().port
+          const client = http2.connect(`http://localhost:${port}`)
+          const req = client.request({ ':path': '/' })
+
+          req.on('error', () => {
+            // Ignore client errors
+          })
+
+          req.on('close', () => {
+            client.close()
+            server.close()
+          })
+
+          req.end()
+        })
+      })
+    })
+  })
+
+  describe('isFinished(res)', function () {
+    it('should return false for unfinished stream', function (done) {
+      const server = http2.createServer()
+
+      server.on('stream', (stream, headers) => {
+        assert.strictEqual(onFinished.isFinished(stream), false)
+        stream.respond({ ':status': 200 })
+        stream.end('hello')
+        done()
+      })
+
+      server.listen(0, function () {
+        const port = server.address().port
+        const client = http2.connect(`http://localhost:${port}`)
+        const req = client.request({ ':path': '/' })
+
+        req.on('response', () => {
+          req.on('end', () => {
+            client.close()
+            server.close()
+          })
+        })
+        req.end()
+      })
+    })
+
+    it('should return true for finished stream', function (done) {
+      const server = http2.createServer()
+
+      server.on('stream', (stream, headers) => {
+        onFinished(stream, () => {
+          assert.strictEqual(onFinished.isFinished(stream), true)
+          done()
+        })
+        stream.respond({ ':status': 200 })
+        setTimeout(() => stream.end('hello'), 10)
+      })
+
+      server.listen(0, function () {
+        const port = server.address().port
+        const client = http2.connect(`http://localhost:${port}`)
+        const req = client.request({ ':path': '/' })
+
+        req.on('response', () => {
+          req.on('end', () => {
+            client.close()
+            server.close()
+          })
+        })
+        req.end()
+      })
+    })
+
+    it('should return true for destroyed stream', function (done) {
+      const server = http2.createServer()
+
+      server.on('stream', (stream, headers) => {
+        stream.respond({ ':status': 200 })
+        setTimeout(() => {
+          stream.destroy()
+          // Check after destroy completes
+          setImmediate(() => {
+            assert.strictEqual(onFinished.isFinished(stream), true)
+            done()
+          })
+        }, 10)
+      })
+
+      server.listen(0, function () {
+        const port = server.address().port
+        const client = http2.connect(`http://localhost:${port}`)
+        const req = client.request({ ':path': '/' })
+
+        req.on('error', () => {
+          // Ignore
+        })
+
+        req.on('close', () => {
+          client.close()
+          server.close()
+        })
+
+        req.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Core Approach:

- Detected HTTP/2 streams using instanceof http2.Http2Stream
- HTTP/2 streams already emit 'close' events naturally - we just needed to listen for them
- Used stream.destroyed and stream.closed properties to check if stream is finished

Related to https://github.com/jshttp/on-finished/issues/57, can you review @Phillip9587 ?