### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "test": "mocha --reporter spec --check-leaks test/",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
+  },
+  "homepage": "https://github.com/jshttp/on-finished",
+  "bugs": {
+    "url": "https://github.com/jshttp/on-finished/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.